### PR TITLE
Fix the emoji picker shortcut on MacOS

### DIFF
--- a/keymap.dtsi
+++ b/keymap.dtsi
@@ -46,6 +46,7 @@
     #define _W      LA
     #define _HOME   _C(LEFT)
     #define _END    _C(RIGHT)
+    #define _EMOJI  LG(LC(SPACE))
 #else
     #define _C      LC
     #define _A_TAB  LALT
@@ -55,6 +56,7 @@
     #define _W      _C
     #define _HOME   HOME
     #define _END    END
+    #define _EMOJI  LG(DOT)
 #endif
 #define _SLEEP      C_SLEEP
 #if OPERATING_SYSTEM == 'W'

--- a/keymap.dtsi.erb
+++ b/keymap.dtsi.erb
@@ -63,6 +63,7 @@
     #define _W      LA
     #define _HOME   _C(LEFT)
     #define _END    _C(RIGHT)
+    #define _EMOJI  LG(LC(SPACE))
 #else
     #define _C      LC
     #define _A_TAB  LALT
@@ -72,6 +73,7 @@
     #define _W      _C
     #define _HOME   HOME
     #define _END    END
+    #define _EMOJI  LG(DOT)
 #endif
 #define _SLEEP      C_SLEEP
 #if OPERATING_SYSTEM == <%= OPERATING_SYSTEMS[:windows] %>

--- a/keymap.json
+++ b/keymap.json
@@ -12487,16 +12487,11 @@
         ]
       },
       {
-        "value": "&kp",
+        "value": "Custom",
         "params": [
           {
-            "value": "LG",
-            "params": [
-              {
-                "value": "DOT",
-                "params": []
-              }
-            ]
+            "value": "&kp _EMOJI",
+            "params": []
           }
         ]
       }


### PR DESCRIPTION
The previous shortcut did not work on MacOS. After this commit, the shortcut should work on mac if the firmware is compiled with macos as the operating system.