### PR TITLE
world: Add LV symbols

### DIFF
--- a/world.yaml
+++ b/world.yaml
@@ -38,7 +38,7 @@ characters:
     diaeresis:  { lower: "ï",  upper: "Ï"  }
     circumflex: { lower: "î",  upper: "Î"  }
     grave:      { lower: "ì",  upper: "Ì"  }
-    macron:     { lower: "ī",  upper: "Ī"  }
+    # macron:     { lower: "ī",  upper: "Ī"  }
   E:
     acute:      { lower: "é",  upper: "É"  }
     diaeresis:  { lower: "ë",  upper: "Ë"  }
@@ -46,7 +46,7 @@ characters:
     grave:      { lower: "è",  upper: "È"  }
     oe:         { lower: "œ",  upper: "Œ"  }
     ae:         { lower: "æ",  upper: "Æ"  }
-    macron:     { lower: "ē",  upper: "Ē"  }
+    # macron:     { lower: "ē",  upper: "Ē"  }
   A:
     acute:      { lower: "á",  upper: "Á"  }
     diaeresis:  { lower: "ä",  upper: "Ä"  }
@@ -54,7 +54,7 @@ characters:
     grave:      { lower: "à",  upper: "À"  }
     tilde:      { lower: "ã",  upper: "Ã"  }
     ring:       { lower: "å",  upper: "Å"  }
-    macron:     { lower: "ā",  upper: "Ā"  }
+    # macron:     { lower: "ā",  upper: "Ā"  }
   Y:
     acute:      { lower: "ý",  upper: "Ý"  }
     diaeresis:  { lower: "ÿ",  upper: "Ÿ"  }
@@ -65,32 +65,32 @@ characters:
     grave:      { lower: "ò",  upper: "Ò"  }
     tilde:      { lower: "õ",  upper: "Õ"  }
     slash:      { lower: "ø",  upper: "Ø"  }
-    macron:     { lower: "ō",  upper: "Ō"  }
+    # macron:     { lower: "ō",  upper: "Ō"  }
   U:
     acute:      { lower: "ú",  upper: "Ú"  }
     diaeresis:  { lower: "ü",  upper: "Ü"  }
     circumflex: { lower: "û",  upper: "Û"  }
     grave:      { lower: "ù",  upper: "Ù"  }
-    macron:     { lower: "ū",  upper: "Ū"  }
-  C:
-    cedilla:    { lower: "ç",  upper: "Ç"  }
-    caron:      { lower: "č",  upper: "Č"  }
-  S:
-    eszett:     { lower: "ß",  upper: "ẞ"  }
-    caron:      { lower: "š",  upper: "Š"  }
-  N:
-    tilde:      { lower: "ñ",  upper: "Ñ"  }
-    cedilla:    { lower: "ņ",  upper: "Ņ"  }
-  G:
-    cedilla:    { lower: "ģ",  upper: "Ģ"  }
-  K:
-    cedilla:    { lower: "ķ",  upper: "Ķ"  }
-  L:
-    cedilla:    { lower: "ļ",  upper: "Ļ"  }
-  Z:
-    caron:      { lower: "ž",  upper: "Ž"  }
-  R:
-    cedilla:    { lower: "ŗ",  upper: "Ŗ"  }
+    # macron:     { lower: "ū",  upper: "Ū"  }
+  # C:
+  #   cedilla:    { lower: "ç",  upper: "Ç"  }
+  #   caron:      { lower: "č",  upper: "Č"  }
+  # S:
+  #   eszett:     { lower: "ß",  upper: "ẞ"  }
+  #   caron:      { lower: "š",  upper: "Š"  }
+  # N:
+  #   tilde:      { lower: "ñ",  upper: "Ñ"  }
+  #   cedilla:    { lower: "ņ",  upper: "Ņ"  }
+  # G:
+  #   cedilla:    { lower: "ģ",  upper: "Ģ"  }
+  # K:
+  #   cedilla:    { lower: "ķ",  upper: "Ķ"  }
+  # L:
+  #   cedilla:    { lower: "ļ",  upper: "Ļ"  }
+  # Z:
+  #   caron:      { lower: "ž",  upper: "Ž"  }
+  # R:
+  #   cedilla:    { lower: "ŗ",  upper: "Ŗ"  }
   consonants:
     cedilla:    { lower: "ç",  upper: "Ç"  }
     eszett:     { lower: "ß",  upper: "ẞ"  }


### PR DESCRIPTION
This adds symbols used in Latvian language, as options in `world.yaml`. The newly added character definitions are commented out and requires the user to enable them if needed. This is done due to size issues - read below in Drawbacks.

## Compositions

Composition definitions have been added for the new symbols. Since these don't affect the `keymap.dtsi` on their own, they are added without commenting them out.

## Consonants

Since 9c943ca195b736923322a8e9b32d8136d2ff01c3 the consonants have been grouped together in a single character group. I don't think it's as useful when the number of different consonants is larger than the few in this group, thus I have added groups for the individual base characters.

I would prefer if the individual consonant letters would have their own letter grouping, same as vowels.

## Drawbacks

On v42-rc8, if all added character definitions are uncommented, the resulting `keymap.dtsi` will be too large to successfully build in the layout editor, presenting a vague error such as "Error time: Sat, 27 Dec 2025 19:00:46 GMT". This is one of the reasons 

In order to build, it is necessary to either:

1. remove some unnecessary character definitions from `world.yaml`. This will reduce the amount of macros in `keymap.dtsi`, and thus the size of the file.
2. remove some of the unnecessary keyboard layers before attempting to rebuild in layout editor.

## Usage

To use the new symbols, user would have to:

1. Uncomment the necessary definitions in `characters:` object;
2. Add additional `transforms` if necessary;
3. remove any unnecessary definitions in `characters:`, enuring there are no references to removed characters in `transforms`. The duplicates in `consonants` are probably a good start, but will likely not be enough.
4. rebuild with `rake` or `./rake`;
5. paste the contents of `keymap.dtsi` into the layout editor;
6. update the key bindings in the layout editor as needed;
7. (optional) remove unnecessary layers;
8. build;

Either (2) or (6) needs to be done to avoid build error, although I have not tested on the newest DEV releases, which already removed some layers - maybe the reduction would already be sufficient.